### PR TITLE
Fix Create Integration Snowflake Macro

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'dbt_object_mgmt'
-version: '0.2.5'
+version: '0.2.6'
 config-version: 2
 
 target-path: "target"

--- a/macros/create_integration.sql
+++ b/macros/create_integration.sql
@@ -11,8 +11,18 @@
 
 {% set integration_name = integration.pop('integration_name') %}
 {% set integration_type = integration.pop('integration_type') %}
-{% set attributes %}
+{% set create_attributes %}
   {%- for key, value in integration.items() %}
+    {%- if value is iterable and value is not string %}
+      {{ key }} = ({{ "\'" + value | join("\', \'") + "\'" }})
+    {%- else %}
+      {{ key }} = {{ value }}
+    {%- endif %}
+  {%- endfor %}
+{% endset %}
+
+{% set alter_attributes %}
+  {%- for key, value in integration.items() if key not in ['type', 'storage_provider'] %}
     {%- if value is iterable and value is not string %}
       {{ key }} = ({{ "\'" + value | join("\', \'") + "\'" }})
     {%- else %}
@@ -27,11 +37,11 @@ begin name create_integration;
 
 {# don't want to delete if already exists :) #}
 create {{ integration_type }} integration if not exists {{ integration_name }}
-{{- attributes }}
+{{- create_attributes }}
 ;
 
 alter {{ integration_type }} integration {{ integration_name }} set
-{{- attributes }}
+{{- alter_attributes }}
 ;
 
 commit;


### PR DESCRIPTION
[ANA-1784](https://spotonteam.atlassian.net/browse/ANA-1784)

### What
Split out the commands, specific to CREATE STORAGE INTEGRATION and ALTER STORAGE INTEGRATION.

### Why
There are keys that should be included in the CREATE statemen, but not part of the alter statement, and will error out if they are included. 



[ANA-1784]: https://spotonteam.atlassian.net/browse/ANA-1784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ