### PR TITLE
Update create_pipe macro for AWS

### DIFF
--- a/macros/create_pipe.sql
+++ b/macros/create_pipe.sql
@@ -22,7 +22,6 @@
   else {}
 %}
 
-
 {% if pipe.extra_format_options %}
   {{ format_type_options.update(pipe.extra_format_options) }}
 {% endif %}
@@ -60,8 +59,6 @@ copy into {{ schema_name }}.{{ table_name }} from (
     )
 {% endset %}
 
-
-
 {%- set sql -%}
 begin name create_pipe;
 
@@ -88,7 +85,7 @@ create or replace table {{ schema_name }}.{{ table_name }} (
 ;
 
 -- First load historic data
-  {{ copy_statement }}
+{{ copy_statement }}
 ;
 
 -- Create pipe

--- a/macros/create_pipe.sql
+++ b/macros/create_pipe.sql
@@ -13,13 +13,23 @@
 {%- set file_type = pipe.file_type %}
 
 {# set some defaults #}
-{%- set format_type_options = {
-    'skip_header': 1,
-    'null_if': ('', 'null'),
-  }
-  if file_type == 'CSV'
-  else {}
-%}
+{% if not pipe.match_by_column_name and not pipe.parse_headers %}
+  {%- set format_type_options = {
+      'skip_header': 1,
+      'null_if': ('', 'null'),
+    }
+    if file_type == 'CSV'
+    else {}
+  %}
+  {%- else %}
+  {%- set format_type_options = {
+      'null_if': ('', 'null'),
+    }
+    if file_type == 'CSV'
+    else {}
+  %}
+{%- endif %}
+
 
 {% if pipe.extra_format_options %}
   {{ format_type_options.update(pipe.extra_format_options) }}
@@ -53,6 +63,20 @@ copy into {{ schema_name }}.{{ table_name }} from (
     )
 {% endset %}
 
+{% set aws_ingest_copy_statement %}
+  copy into {{ schema_name }}.{{ table_name }}
+  from @{{ schema_name }}.{{ table_name }}_stage
+  file_format = (
+    type = '{{ file_type }}'
+    {% for key, value in format_type_options.items() %}
+      {{- key }} = {{ value }}
+    {% endfor -%}
+    )
+  {{ "match_by_column_name = '" ~ pipe.match_by_column_name ~ "'" if pipe.match_by_column_name }}
+  {{ "pattern = '" ~ pipe.pattern ~ "'" if pipe.pattern }}
+  on_error = continue
+{% endset %}
+
 
 {%- set sql -%}
 begin name create_pipe;
@@ -80,12 +104,20 @@ create or replace table {{ schema_name }}.{{ table_name }} (
 ;
 
 -- First load historic data
-{{ copy_statement }}
+{% if not pipe.match_by_column_name and not pipe.parse_headers %}
+  {{ copy_statement }}
+ {%- else %}
+  {{ aws_ingest_copy_statement }}
+{%- endif %}
 ;
 
 -- Create pipe
 create or replace pipe {{ schema_name }}.{{ table_name }}_pipe auto_ingest = true as
-{{ copy_statement }}
+{% if not pipe.match_by_column_name and not pipe.parse_headers %}
+  {{ copy_statement }}
+ {%- else %}
+  {{ aws_ingest_copy_statement }}
+{%- endif %}
 ;
 
 commit;


### PR DESCRIPTION
### What

Update the create_pipe macro/script 

### Why
To accomodate the [additional COPY INTO options](https://docs.snowflake.com/en/sql-reference/sql/copy-into-table#loading-files-using-column-matching) that the AWS Cost Pipe needs (as well as excluding some default options, such as SKIP_HEADER).

### Notes
1) I pointed to the local version of this repo for testing the logic with the create_pipe macro, and I was able to confirm that the SQL renders as intended with both previous pipe configs, as well as the AWS Cost pipe config.

2) The main conditional checks for the presence of pipe.match_by_column_name  pipe.parse_headers values. Would a better approach to be just adding a new key:value to the top of the config specifying that this is the aws cost ingestion, and having our logic check that value?

This PR is a prerequisite for the [AWS Cost Pipe Config changes PR](https://github.com/SpotOnInc/analytics-dbt/pull/933)

@yoitsbenc @DanCorley 