### PR TITLE
set default quoting for CSV

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'dbt_object_mgmt'
-version: '0.2.7'
+version: '0.2.8'
 config-version: 2
 
 target-path: "target"

--- a/macros/create_pipe.sql
+++ b/macros/create_pipe.sql
@@ -17,7 +17,8 @@
 {%- set format_type_options = {
     'skip_header': 1,
     'null_if': ('', 'null'),
-    'error_on_column_count_mismatch': true
+    'error_on_column_count_mismatch': true,
+    'field_optionally_enclosed_by': '"',
   }
   if file_type == 'CSV'
   else {}


### PR DESCRIPTION
seeing an uptick in errors on load dealing with double quoting in CSVs. adding that as a default.