### PR TITLE
add in metadata for match_by_column_name

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -2,6 +2,8 @@ name: 'dbt_object_mgmt'
 version: '0.2.10'
 config-version: 2
 
+profile: 'dbt_object_mgmt'
+
 target-path: "target"
 macro-paths: ["macros"]
 log-path: "logs"
@@ -14,3 +16,4 @@ vars:
   snowflake_user_file: snowflake/users/users.yml
   snowflake_network_policy_file: snowflake/policy/network_policies.yml
   snowflake_admin: securityadmin
+  dry_run: true

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'dbt_object_mgmt'
-version: '0.2.7'
+version: '0.2.10'
 config-version: 2
 
 target-path: "target"

--- a/macros/create_pipe.sql
+++ b/macros/create_pipe.sql
@@ -28,6 +28,15 @@
   {{ format_type_options.update(pipe.extra_format_options) }}
 {% endif %}
 
+{% set metadata_columns = {
+      'file_name': 'metadata$filename',
+      'file_id': 'metadata$file_content_key',
+      'row_number': 'metadata$file_row_number',
+      'last_modified_time': 'metadata$file_last_modified',
+      'load_time': 'metadata$start_scan_time',
+  }
+%}
+
 {% set copy_statement -%}
 copy into {{ schema_name }}.{{ table_name }} from
 {% if pipe.match_by_column_name %}
@@ -42,11 +51,9 @@ copy into {{ schema_name }}.{{ table_name }} from
 
   {% if pipe.match_by_column_name -%}
     include_metadata = (
-      file_name = metadata$filename
-      file_id = metadata$file_content_key
-      row_number = metadata$file_row_number
-      last_modified_time = metadata$file_last_modified
-      load_time = metadata$start_scan_time
+      {% for key, value in metadata_columns.items() %}
+        {{- key }} = {{ value }}{{ ', ' if not loop.last }}
+      {% endfor %}
     )
   {%- endif %}
 
@@ -59,11 +66,7 @@ copy into {{ schema_name }}.{{ table_name }} from
       {{ ', ' if not loop.first }}${{ loop.index }}
       {%- endfor %}
       {%- endif %}
-      , metadata$filename
-      , md5(metadata$filename)
-      , metadata$file_row_number
-      , metadata$file_last_modified
-      , metadata$start_scan_time
+      , {{ metadata_columns.values() | join(', ') -}}
     from
       @{{ schema_name }}.{{ table_name }}_stage
   )
@@ -74,8 +77,8 @@ copy into {{ schema_name }}.{{ table_name }} from
     type = '{{ file_type }}'
     {% for key, value in format_type_options.items() %}
       {{- key }} = {{ value }}
-    {% endfor -%}
-    )
+    {% endfor %}
+  )
 {% endset %}
 
 {%- set sql -%}

--- a/macros/create_pipe.sql
+++ b/macros/create_pipe.sql
@@ -39,6 +39,17 @@ copy into {{ schema_name }}.{{ table_name }} from
   -#}
   @{{ schema_name }}.{{ table_name }}_stage
   {{ "match_by_column_name = " ~ pipe.match_by_column_name }}
+
+  {% if pipe.match_by_column_name -%}
+    include_metadata = (
+      file_name = metadata$filename
+      file_id = metadata$file_content_key
+      row_number = metadata$file_row_number
+      last_modified_time = metadata$file_last_modified
+      load_time = metadata$start_scan_time
+    )
+  {%- endif %}
+
 {% else %} (
     select
       {%- if file_type == 'JSON' %}

--- a/snowflake/snowpipe/s3_pipe_jaffle_shop_customers_match_column_name.yml
+++ b/snowflake/snowpipe/s3_pipe_jaffle_shop_customers_match_column_name.yml
@@ -1,0 +1,14 @@
+integration_name: jaffle_shop_integration
+schema_name: raw_jaffle_shop
+table_name: jaffle_shop_customers
+s3_url: 's3://jaffle_shop/customers/'
+file_type: 'CSV'
+match_by_column_name: case_insensitive
+extra_format_options:
+  parse_header: true
+  skip_header: 0
+  error_on_column_count_mismatch: false
+columns:
+  id: text
+  first_name: text
+  last_name: text


### PR DESCRIPTION
from #22 we lost the ability to garner metadata of files when loading in matching by column name. this adds back with newer   copy option `INCLUDE_METADATA`

when using match_by_column name, the copy statement will be
```sql
copy into analytics.raw_jaffle_shop.jaffle_shop_customers from

  @analytics.raw_jaffle_shop.jaffle_shop_customers_stage
  match_by_column_name = case_insensitive

  include_metadata = (
      file_name = metadata$filename, 
      file_id = metadata$file_content_key, 
      row_number = metadata$file_row_number, 
      last_modified_time = metadata$file_last_modified, 
      load_time = metadata$start_scan_time
      
    )
...
```

and normal will compile to 

```sql
copy into analytics.raw_jaffle_shop.jaffle_shop_customers from
 (
    select
      $1
      , $2
      , $3
      , metadata$filename, metadata$file_content_key, metadata$file_row_number, metadata$file_last_modified, metadata$start_scan_timefrom
      @analytics.raw_jaffle_shop.jaffle_shop_customers_stage
  )
...
```
