### PR TITLE
modify whitespace for metadata / from separation

### DIFF
--- a/macros/create_pipe.sql
+++ b/macros/create_pipe.sql
@@ -66,7 +66,7 @@ copy into {{ schema_name }}.{{ table_name }} from
       {{ ', ' if not loop.first }}${{ loop.index }}
       {%- endfor %}
       {%- endif %}
-      , {{ metadata_columns.values() | join(', ') -}}
+      , {{ metadata_columns.values() | join(', ') }}
     from
       @{{ schema_name }}.{{ table_name }}_stage
   )


### PR DESCRIPTION
currently the metadata columns handle whitespace at the end of the copy into statement, which results in `from` getting too cozy, resulting in error:

```sql
-- CURRENTLY
copy into database.schema.table
 (
    select
      $1
      , metadata$filename, metadata$file_content_key, metadata$file_row_number, metadata$file_last_modified, metadata$start_scan_timefrom
      @database.schema.table_stage
  )
```

```sql
-- CHANGING TO
 (
    select
      $1
      , metadata$filename, metadata$file_content_key, metadata$file_row_number, metadata$file_last_modified, metadata$start_scan_time
    from
      @raw_prod.raw_fis.emaf_stage
  )
```