### PR TITLE
qualify namespace

### DIFF
--- a/macros/create_integration.sql
+++ b/macros/create_integration.sql
@@ -7,7 +7,7 @@
   ) }}
 {% endif %}
 
-{% set integration = gather_results(file) %}
+{% set integration = dbt_object_mgmt.gather_results(file) %}
 
 {% set integration_name = integration.pop('integration_name') %}
 {% set integration_type = integration.pop('integration_type') %}

--- a/macros/create_network_policies.sql
+++ b/macros/create_network_policies.sql
@@ -2,7 +2,7 @@
 
 {% set file = var('snowflake_network_policy_file' , 'snowflake/whitelist/network_policies.yml') %}
 
-{% set policy_list = gather_results(file) %}
+{% set policy_list = dbt_object_mgmt.gather_results(file) %}
 
 
 {% set network_policy_sql %}

--- a/macros/create_pipe.sql
+++ b/macros/create_pipe.sql
@@ -7,7 +7,7 @@
   ) }}
 {% endif %}
 
-{% set pipe = gather_results(file) %}
+{% set pipe = dbt_object_mgmt.gather_results(file) %}
 {%- set database_name = pipe.database_name or target.database %}
 {%- set schema_name = database_name ~ '.' ~ pipe.schema_name %}
 {%- set table_name = pipe.table_name %}

--- a/macros/create_task.sql
+++ b/macros/create_task.sql
@@ -7,7 +7,7 @@
   ) }}
 {% endif %}
 
-{% set task = gather_results(file) %}
+{% set task = dbt_object_mgmt.gather_results(file) %}
 
 {# set the non-standard kay:values #}
 {% set task_name = task.pop('task_name') %}

--- a/macros/create_users.sql
+++ b/macros/create_users.sql
@@ -4,7 +4,7 @@
 {%- set _password = var('password', 's0up3rs$cr3t') %}
 {% set must_quote_columns = ['email', 'comment', 'rsa_public_key', 'display_name', 'first_name', 'last_name', 'middle_name'] %}
 
-{% set user_list = gather_results(file) %}
+{% set user_list = dbt_object_mgmt.gather_results(file) %}
 
 
 {%- set user_sql -%}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-dbt-snowflake==1.0.0
-sqlfluff-templater-dbt==0.11.1
-python-dotenv==0.19.2
-snowflake-connector-python==2.8.0
-
+dbt-core==1.9.4
+dbt-snowflake==1.9.4
+sqlfluff-templater-dbt==3.4.1
+snowflake-connector-python==3.12.2


### PR DESCRIPTION
This pull request refactors several macros to consistently use the `dbt_object_mgmt` namespace for utility functions and result gathering, improving code organization and maintainability. The changes affect both object creation macros and utility macros, centralizing the logic within the `dbt_object_mgmt` module.

Refactoring to use `dbt_object_mgmt` namespace allows for others to reuse macros outside of dbt_object_mgmt package. Before users would receive this error
```sql
18:02:42  Encountered an error while running operation: Compilation Error
  'put_file' is undefined
  
  > in macro macro_name (macros/macro_name.sql)
  > called by <Unknown>
```