### PR TITLE
update match_by_column_name

### DIFF
--- a/macros/create_pipe.sql
+++ b/macros/create_pipe.sql
@@ -70,7 +70,7 @@ copy into {{ schema_name }}.{{ table_name }} from
   {% if pipe.match_by_column_name -%}
     include_metadata = (
       {% for key, value in metadata_columns.items() %}
-        {{- key }} = {{ value }}{{ ', ' if not loop.last }}
+        {{- key }} = {{ value.get('source') }}{{ ', ' if not loop.last }}
       {% endfor %}
     )
   {%- endif %}


### PR DESCRIPTION
following #25 to update match_by_column_name include_metadata to pull from the dict `value.source` instead of just `value`.

```sql
-- FROM
include_metadata = (
    file_name = {'source': 'metadata$filename', 'type': 'text'}, 
    file_id = {'source': 'metadata$file_content_key', 'type': 'text'}, 
    row_number = {'source': 'metadata$file_row_number', 'type': 'integer'}, 
    last_modified_time = {'source': 'metadata$file_last_modified', 'type': 'timestamp_ntz'}, 
    load_time = {'source': 'metadata$start_scan_time', 'type': 'timestamp_ltz'}
    
  ) 

-- TO
include_metadata = (
    file_name = metadata$filename, 
    file_id = metadata$file_content_key, 
    row_number = metadata$file_row_number, 
    last_modified_time = metadata$file_last_modified, 
    load_time = metadata$start_scan_time
    
  )

```