### PR TITLE
Feat/refactor for reusability

### DIFF
--- a/macros/create_integration.sql
+++ b/macros/create_integration.sql
@@ -1,11 +1,6 @@
 {%- macro create_integration(file) -%}
 
-{% if not file %}
-  {{ exceptions.raise_compiler_error(
-    "\nyou must pass in a file via arguments:" ~
-    "\n  --args 'file: ./snowflake/integration/s3_to_snowflake_integration.yml'"
-  ) }}
-{% endif %}
+{{ dbt_object_mgmt._require_file(file, './snowflake/integration/s3_to_snowflake_integration.yml') }}
 
 {% set integration = dbt_object_mgmt.gather_results(file) %}
 
@@ -47,9 +42,6 @@ alter {{ integration_type }} integration {{ integration_name }} set
 commit;
 {%- endset -%}
 
-{{ log(sql, info=True) }}
-{% if not var('dry_run', False) %}
-  {{ run_query(sql) }}
-{% endif %}
+{{ dbt_object_mgmt._execute(sql) }}
 
 {%- endmacro -%}

--- a/macros/create_network_policies.sql
+++ b/macros/create_network_policies.sql
@@ -35,9 +35,6 @@ use role {{ var('snowflake_admin', 'securityadmin') }};
 commit;
 {% endset %}
 
-{{ log(network_policy_sql, info=True) }}
-{% if not var('dry_run', False) %}
-  {{ run_query(network_policy_sql) }}
-{% endif %}
+{{ dbt_object_mgmt._execute(network_policy_sql) }}
 
 {% endmacro %}

--- a/macros/create_pipe.sql
+++ b/macros/create_pipe.sql
@@ -8,18 +8,7 @@
 {%- set table_name = pipe.table_name %}
 {%- set file_type = pipe.file_type %}
 
-{%- set format_options = {
-    'skip_header': 1,
-    'null_if': ('', 'null'),
-    'error_on_column_count_mismatch': true,
-    'field_optionally_enclosed_by': '\'"\''
-  }
-  if file_type == 'CSV'
-  else {}
-%}
-{% if pipe.extra_format_options %}
-  {{ format_options.update(pipe.extra_format_options) }}
-{% endif %}
+{%- set format_options = dbt_object_mgmt._build_format_options(file_type, pipe.extra_format_options) -%}
 
 {%- set metadata_columns = dbt_object_mgmt._resolve_metadata_columns(pipe.custom_metadata_columns) -%}
 

--- a/macros/create_pipe.sql
+++ b/macros/create_pipe.sql
@@ -1,11 +1,6 @@
 {%- macro create_pipe(file) -%}
 
-{% if not file %}
-  {{ exceptions.raise_compiler_error(
-    "\nyou must pass in a file via arguments:" ~
-    "\n  --args 'file: ./snowflake/snowpipe/s3_pipe_jaffle_shop_customers.yml'"
-  ) }}
-{% endif %}
+{{ dbt_object_mgmt._require_file(file, './snowflake/snowpipe/s3_pipe_jaffle_shop_customers.yml') }}
 
 {% set pipe = dbt_object_mgmt.gather_results(file) %}
 {%- set database_name = pipe.database_name or target.database %}
@@ -13,93 +8,24 @@
 {%- set table_name = pipe.table_name %}
 {%- set file_type = pipe.file_type %}
 
-{# set some defaults #}
-{%- set format_type_options = {
+{%- set format_options = {
     'skip_header': 1,
     'null_if': ('', 'null'),
     'error_on_column_count_mismatch': true,
-    'field_optionally_enclosed_by': '\'"\'', 
+    'field_optionally_enclosed_by': '\'"\''
   }
   if file_type == 'CSV'
   else {}
 %}
-
 {% if pipe.extra_format_options %}
-  {{ format_type_options.update(pipe.extra_format_options) }}
+  {{ format_options.update(pipe.extra_format_options) }}
 {% endif %}
 
-{% set metadata_columns = {
-      'file_name':          {'source':'metadata$filename',           'type':'text',},
-      'file_id':            {'source':'metadata$file_content_key',   'type':'text',},
-      'row_number':         {'source':'metadata$file_row_number',    'type':'integer',},
-      'last_modified_time': {'source':'metadata$file_last_modified', 'type':'timestamp_ntz',},
-      'load_time':          {'source':'metadata$start_scan_time',    'type':'timestamp_ltz',},
-  }
-%}
-
-{# Update with custom metadata column overrides #}
-{% if pipe.custom_metadata_columns %}
-  {% for col_name, config in pipe.custom_metadata_columns.items() %}
-    {% if metadata_columns.get(col_name) %} {# If column already exists, update it #}
-      {% if config is mapping %} {# If config is a dict (column: {source: ..., type: ...}) #}
-          {% for key, value in config.items() %}
-            {% do metadata_columns[col_name].update({key: value}) %}
-          {% endfor %}
-      {% else %} {# If config is just a string (column: source) #}
-        {% do metadata_columns[col_name].update({'source': config}) %}
-      {% endif %}
-    {% else %} {# If column doesn't exist, add it #}
-      {% do metadata_columns.update({col_name: config}) %}  
-    {% endif %}
-  {% endfor %}
-{% endif %}
-
+{%- set metadata_columns = dbt_object_mgmt._resolve_metadata_columns(pipe.custom_metadata_columns) -%}
 
 {% set copy_statement -%}
-copy into {{ schema_name }}.{{ table_name }} from
-{% if pipe.match_by_column_name %}
-  {# if match_by_column_name, reccomended to set this in the pipe definition
-    extra_format_options:
-      parse_header: true
-      skip_header: 0
-      error_on_column_count_mismatch: false
-  -#}
-  @{{ schema_name }}.{{ table_name }}_stage
-  {{ "match_by_column_name = " ~ pipe.match_by_column_name }}
-
-  {% if pipe.match_by_column_name -%}
-    include_metadata = (
-      {% for key, value in metadata_columns.items() %}
-        {{- key }} = {{ value.get('source') }}{{ ', ' if not loop.last }}
-      {% endfor %}
-    )
-  {%- endif %}
-
-{% else %} (
-    select
-      {%- if file_type == 'JSON' %}
-      parse_json($1)
-      {%- else %}
-      {%- for col in pipe.columns %}
-      {{ ', ' if not loop.first }}${{ loop.index }}
-      {%- endfor %}
-      {%- endif %}
-      {% for config in metadata_columns.values() -%}
-      , {{ config.get('source') }}
-      {%- endfor %}
-    from
-      @{{ schema_name }}.{{ table_name }}_stage
-  )
-  {% endif %}
-  on_error = continue
-  {{ "pattern = '" ~ pipe.pattern ~ "'" if pipe.pattern }}
-  file_format = (
-    type = '{{ file_type }}'
-    {% for key, value in format_type_options.items() %}
-      {{- key }} = {{ value }}
-    {% endfor %}
-  )
-{% endset %}
+  {{ dbt_object_mgmt._build_copy_statement(pipe, schema_name, metadata_columns, format_options) }}
+{%- endset %}
 
 {%- set sql -%}
 begin name create_pipe;
@@ -138,8 +64,5 @@ create or replace pipe {{ schema_name }}.{{ table_name }}_pipe auto_ingest = tru
 commit;
 {%- endset -%}
 
-{%- do log(sql, info=True) -%}
-{% if not var('dry_run', False) %}
-  {%- do run_query(sql) -%}
-{% endif %}
+{{ dbt_object_mgmt._execute(sql) }}
 {%- endmacro -%}

--- a/macros/create_task.sql
+++ b/macros/create_task.sql
@@ -1,11 +1,6 @@
 {% macro create_task(file) %}
 
-{% if not file %}
-  {{ exceptions.raise_compiler_error(
-    "\nyou must pass in a file via arguments:" ~
-    "\n  --args 'file: ./snowflake/snowpipe/s3_pipe_jaffle_shop_customers.yml'"
-  ) }}
-{% endif %}
+{{ dbt_object_mgmt._require_file(file, './snowflake/snowpipe/s3_pipe_jaffle_shop_customers.yml') }}
 
 {% set task = dbt_object_mgmt.gather_results(file) %}
 

--- a/macros/create_users.sql
+++ b/macros/create_users.sql
@@ -51,9 +51,6 @@ commit;
 {%- endset %}
 
 
-{% do log(user_sql, info=True) %}
-{% if not var('dry_run', False) %}
-  {{ run_query(user_sql) }}
-{% endif %}
+{{ dbt_object_mgmt._execute(user_sql) }}
 
 {% endmacro %}

--- a/macros/reload_pipe_file.sql
+++ b/macros/reload_pipe_file.sql
@@ -9,32 +9,12 @@
 {%- set table_name = pipe.table_name %}
 {%- set file_type = pipe.file_type %}
 
-{%- set format_options = {
-    'skip_header': 1,
-    'null_if': ('', 'null'),
-    'error_on_column_count_mismatch': true,
-    'field_optionally_enclosed_by': '\'"\''
-  }
-  if file_type == 'CSV'
-  else {}
-%}
-{% if pipe.extra_format_options %}
-  {{ format_options.update(pipe.extra_format_options) }}
-{% endif %}
+{%- set format_options = dbt_object_mgmt._build_format_options(file_type, pipe.extra_format_options) -%}
 
 {%- set metadata_columns = dbt_object_mgmt._resolve_metadata_columns(pipe.custom_metadata_columns) -%}
 
 {% set copy_statement -%}
-copy into {{ schema_name }}.{{ table_name }}_temp
-{% if pipe.match_by_column_name %}
-  from @{{ schema_name }}.{{ table_name }}_stage
-  {{ "match_by_column_name = " ~ pipe.match_by_column_name }}
-{% else %}
-  from {{ dbt_object_mgmt._build_copy_select(pipe.columns, file_type, metadata_columns, stage) }}
-{% endif %}
-  on_error = continue
-  pattern = $file_name
-  {{ dbt_object_mgmt._build_file_format(file_type, format_options) }}
+  {{ dbt_object_mgmt._build_copy_statement(pipe, schema_name, metadata_columns, format_options, target_table=schema_name~'.'~table_name~'_temp', raw_pattern='$file_name') }}
 {%- endset %}
 
 
@@ -42,7 +22,7 @@ copy into {{ schema_name }}.{{ table_name }}_temp
 
 -- Drop the file needing to be reloaded
 delete from {{ schema_name }}.{{ table_name }}
-  where file_name ilike $file_name
+  where file_name = '{{ file_name }}'
 ;
 
 -- Create a temp table to load data

--- a/macros/reload_pipe_file.sql
+++ b/macros/reload_pipe_file.sql
@@ -1,0 +1,68 @@
+{%- macro reload_pipe_file(file, file_name) -%}
+
+{{ dbt_object_mgmt._require_file(file, './snowflake/snowpipe/s3_pipe_jaffle_shop_customers.yml') }}
+
+{%- set file_name = file_name or var('file_name') -%}
+{%- set pipe = dbt_object_mgmt.gather_results(file) -%}
+{%- set database_name = pipe.database_name or target.database %}
+{%- set schema_name = database_name ~ '.' ~ pipe.schema_name %}
+{%- set table_name = pipe.table_name %}
+{%- set file_type = pipe.file_type %}
+
+{%- set format_options = {
+    'skip_header': 1,
+    'null_if': ('', 'null'),
+    'error_on_column_count_mismatch': true,
+    'field_optionally_enclosed_by': '\'"\''
+  }
+  if file_type == 'CSV'
+  else {}
+%}
+{% if pipe.extra_format_options %}
+  {{ format_options.update(pipe.extra_format_options) }}
+{% endif %}
+
+{%- set metadata_columns = dbt_object_mgmt._resolve_metadata_columns(pipe.custom_metadata_columns) -%}
+
+{% set copy_statement -%}
+copy into {{ schema_name }}.{{ table_name }}_temp
+{% if pipe.match_by_column_name %}
+  from @{{ schema_name }}.{{ table_name }}_stage
+  {{ "match_by_column_name = " ~ pipe.match_by_column_name }}
+{% else %}
+  from {{ dbt_object_mgmt._build_copy_select(pipe.columns, file_type, metadata_columns, stage) }}
+{% endif %}
+  on_error = continue
+  pattern = $file_name
+  {{ dbt_object_mgmt._build_file_format(file_type, format_options) }}
+{%- endset %}
+
+
+{%- set sql -%}
+
+-- Drop the file needing to be reloaded
+delete from {{ schema_name }}.{{ table_name }}
+  where file_name ilike $file_name
+;
+
+-- Create a temp table to load data
+create or replace temporary table
+  {{ schema_name }}.{{ table_name }}_temp
+  like {{ schema_name }}.{{ table_name }}
+;
+
+-- Load file by name
+{{ copy_statement }}
+;
+
+-- merge these back into the original table
+insert into {{ schema_name }}.{{ table_name }}
+  select * from {{ schema_name }}.{{ table_name }}_temp
+;
+
+{%- endset -%}
+
+{{ dbt_object_mgmt._execute(sql) }}
+{%- do log("Loaded " ~ file_name ~ " to table " ~ schema_name ~ "." ~ table_name, info=True) -%}
+
+{%- endmacro -%}

--- a/macros/utils/execution.sql
+++ b/macros/utils/execution.sql
@@ -1,0 +1,16 @@
+{% macro _require_file(file, example_path='') %}
+  {% if not file %}
+    {{ exceptions.raise_compiler_error(
+      "\nyou must pass in a file via arguments:" ~
+      ("\n  --args 'file: " ~ example_path ~ "'" if example_path else "")
+    ) }}
+  {% endif %}
+{% endmacro %}
+
+
+{% macro _execute(sql) %}
+  {%- do log(sql, info=True) -%}
+  {% if not var('dry_run', False) %}
+    {%- do run_query(sql) -%}
+  {% endif %}
+{% endmacro %}

--- a/macros/utils/pipe_helpers.sql
+++ b/macros/utils/pipe_helpers.sql
@@ -56,10 +56,28 @@ file_format = (
 {% endmacro %}
 
 
-{% macro _build_copy_statement(pipe, schema_name, metadata_columns, format_options) %}
+{% macro _build_format_options(file_type, extra_format_options=none) %}
+  {%- set format_options = {
+      'skip_header': 1,
+      'null_if': ('', 'null'),
+      'error_on_column_count_mismatch': true,
+      'field_optionally_enclosed_by': "'\"'"
+    }
+    if file_type == 'CSV'
+    else {}
+  -%}
+  {%- if extra_format_options -%}
+    {%- do format_options.update(extra_format_options) -%}
+  {%- endif -%}
+  {{ return(format_options) }}
+{% endmacro %}
+
+
+{% macro _build_copy_statement(pipe, schema_name, metadata_columns, format_options, target_table=none, raw_pattern=none) %}
 {%- set table_name = pipe.table_name -%}
 {%- set stage = schema_name ~ '.' ~ table_name ~ '_stage' -%}
-copy into {{ schema_name }}.{{ table_name }} from
+{%- set dest = target_table if target_table is not none else schema_name ~ '.' ~ table_name -%}
+copy into {{ dest }} from
 {% if pipe.match_by_column_name %}
   {# if match_by_column_name, recommended to set in the pipe definition:
     extra_format_options:
@@ -82,6 +100,10 @@ copy into {{ schema_name }}.{{ table_name }} from
   {{ dbt_object_mgmt._build_copy_select(pipe.columns, pipe.file_type, metadata_columns, stage) }}
 {% endif %}
   on_error = continue
-  {{ "pattern = '" ~ pipe.pattern ~ "'" if pipe.pattern }}
+  {%- if raw_pattern is not none %}
+  pattern = {{ raw_pattern }}
+  {%- elif pipe.pattern %}
+  {{ "pattern = '" ~ pipe.pattern ~ "'" }}
+  {%- endif %}
   {{ dbt_object_mgmt._build_file_format(pipe.file_type, format_options) }}
 {% endmacro %}

--- a/macros/utils/pipe_helpers.sql
+++ b/macros/utils/pipe_helpers.sql
@@ -1,0 +1,87 @@
+{% macro _resolve_metadata_columns(custom_overrides=None) %}
+  {%- set metadata_columns = {
+      'file_name':          {'source': 'metadata$filename',           'type': 'text'},
+      'file_id':            {'source': 'metadata$file_content_key',   'type': 'text'},
+      'row_number':         {'source': 'metadata$file_row_number',    'type': 'integer'},
+      'last_modified_time': {'source': 'metadata$file_last_modified', 'type': 'timestamp_ntz'},
+      'load_time':          {'source': 'metadata$start_scan_time',    'type': 'timestamp_ltz'},
+  } -%}
+
+  {%- if custom_overrides -%}
+    {%- for col_name, config in custom_overrides.items() -%}
+      {%- if metadata_columns.get(col_name) -%}
+        {%- if config is mapping -%}
+          {%- for key, value in config.items() -%}
+            {%- do metadata_columns[col_name].update({key: value}) -%}
+          {%- endfor -%}
+        {%- else -%}
+          {%- do metadata_columns[col_name].update({'source': config}) -%}
+        {%- endif -%}
+      {%- else -%}
+        {%- do metadata_columns.update({col_name: config}) -%}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- endif -%}
+
+  {{ return(metadata_columns) }}
+{% endmacro %}
+
+
+{% macro _build_copy_select(columns, file_type, metadata_columns, stage) %}
+(
+    select
+      {%- if file_type == 'JSON' %}
+      parse_json($1)
+      {%- else %}
+      {%- for col in columns %}
+      {{ ', ' if not loop.first }}${{ loop.index }}
+      {%- endfor %}
+      {%- endif %}
+      {% for config in metadata_columns.values() -%}
+      , {{ config.get('source') }}
+      {%- endfor %}
+    from
+      @{{ stage }}
+  )
+{% endmacro %}
+
+
+{% macro _build_file_format(file_type, format_options={}) %}
+file_format = (
+    type = '{{ file_type }}'
+    {% for key, value in format_options.items() %}
+      {{- key }} = {{ value }}
+    {% endfor %}
+  )
+{% endmacro %}
+
+
+{% macro _build_copy_statement(pipe, schema_name, metadata_columns, format_options) %}
+{%- set table_name = pipe.table_name -%}
+{%- set stage = schema_name ~ '.' ~ table_name ~ '_stage' -%}
+copy into {{ schema_name }}.{{ table_name }} from
+{% if pipe.match_by_column_name %}
+  {# if match_by_column_name, recommended to set in the pipe definition:
+    extra_format_options:
+      parse_header: true
+      skip_header: 0
+      error_on_column_count_mismatch: false
+  -#}
+  @{{ stage }}
+  {{ "match_by_column_name = " ~ pipe.match_by_column_name }}
+
+  {%- if pipe.match_by_column_name %}
+  include_metadata = (
+    {% for key, value in metadata_columns.items() %}
+      {{- key }} = {{ value.get('source') }}{{ ', ' if not loop.last }}
+    {% endfor %}
+  )
+  {%- endif %}
+
+{% else %}
+  {{ dbt_object_mgmt._build_copy_select(pipe.columns, pipe.file_type, metadata_columns, stage) }}
+{% endif %}
+  on_error = continue
+  {{ "pattern = '" ~ pipe.pattern ~ "'" if pipe.pattern }}
+  {{ dbt_object_mgmt._build_file_format(pipe.file_type, format_options) }}
+{% endmacro %}


### PR DESCRIPTION
This pull request refactors and standardizes the macros for creating and managing Snowflake integrations, pipes, tasks, users, and network policies. The main focus is on improving code reuse, maintainability, and consistency by extracting common logic into utility macros and simplifying the main macros. Additionally, a new macro for reloading a specific file into a Snowpipe-managed table is introduced.

The most important changes are:

**Macro Refactoring and Code Reuse:**
* Introduced utility macros in `macros/utils/execution.sql` for requiring a file argument (`_require_file`) and executing SQL with logging and dry-run support (`_execute`). Main macros now use these utilities instead of duplicating logic.
* Extracted logic for building format options, resolving metadata columns, and constructing copy statements into helper macros in `macros/utils/pipe_helpers.sql`, significantly simplifying `create_pipe.sql` and related macros.

**Macro Simplification and Consistency:**
* Refactored `create_integration.sql`, `create_pipe.sql`, `create_task.sql`, `create_users.sql`, and `create_network_policies.sql` to use the new utility and helper macros, removing duplicated error handling and SQL execution code.

**New Functionality:**
* Added the `reload_pipe_file` macro, allowing targeted reloading of a specific file into a Snowpipe-managed table, including safe deletion and re-insertion logic.

These changes improve maintainability, reduce code duplication, and provide a clearer structure for managing Snowflake objects via dbt macros.