### PR TITLE
Feat/create mcp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,36 @@ This macro manages [tasks](https://docs.snowflake.com/en/sql-reference/sql/creat
 
 </details>
 
+___
+### [create_mcp_server](./macros/create_mcp_server.sql)
+
+This macro manages Snowflake [MCP (Model Context Protocol) servers](https://docs.snowflake.com/en/sql-reference/sql/create-mcp-server) using `CREATE OR REPLACE` syntax, taking a 1:1 file to MCP server approach. The server name is automatically qualified to `database.schema.name` using the target profile values when a partial name is provided.
+<details>
+  <summary>command line and file parameters</summary>
+
+  ##### command line
+  ```bash
+  dbt run-operation create_mcp_server \
+    --args 'file: ./snowflake/mcp_server/my_mcp_server.yml'
+  ```
+
+  ##### file parameters
+  - **server_name**: identifier for the MCP server. Supports partial qualification — a bare name gets `target.database.target.schema` prepended, a `schema.name` gets `target.database` prepended, and a fully qualified `database.schema.name` is used as-is.
+  - **tools**: list of tool definitions. Each tool supports:
+    - **name** *(required)*: unique name for the tool within the server
+    - **type** *(required)*: one of `CORTEX_SEARCH_SERVICE_QUERY`, `CORTEX_ANALYST_MESSAGE`, `CORTEX_AGENT_RUN`, `SYSTEM_EXECUTE_SQL`, or `GENERIC`
+    - **title**: display name for the tool
+    - **description**: description of what the tool does
+    - **identifier**: fully qualified reference to the backing Snowflake object (required for all types except `SYSTEM_EXECUTE_SQL`)
+    - **config** *(GENERIC only)*:
+      - **type**: `function` or `procedure`
+      - **warehouse**: warehouse to use for execution
+      - **input_schema**: JSON Schema object defining tool inputs, with `type` and `properties` (each property has `description` and `type`)
+
+  See the [example config](./snowflake/mcp_server/example_mcp_server.yml) for all four tool types.
+
+</details>
+
 ______
 ### [create_pipe](./macros/create_pipe.sql)
 

--- a/macros/create_mcp_server.sql
+++ b/macros/create_mcp_server.sql
@@ -1,0 +1,79 @@
+{%- macro create_mcp_server(file) -%}
+
+{% if not file %}
+  {{ exceptions.raise_compiler_error(
+    "\nyou must pass in a file via arguments:" ~
+    "\n  --args 'file: ./snowflake/mcp_server/my_mcp_server.yml'"
+  ) }}
+{% endif %}
+
+{% set config = dbt_object_mgmt.gather_results(file) %}
+
+{# qualify server_name to db.schema.name, db.name, or as-is depending on dot count #}
+{%- set server_name = config.pop('server_name') %}
+{%- set prefix = {
+    1: target.database ~ '.' ~ target.schema ~ '.',
+    2: target.database ~ '.'
+  }.get(server_name.split('.') | length, '') -%}
+{%- set server_name = prefix ~ server_name %}
+
+
+{%- set tools = config.pop('tools', []) %}
+
+{# Build the YAML specification by constructing each line explicitly #}
+{%- set spec_lines = [] %}
+{%- do spec_lines.append('tools:') %}
+{%- for tool in tools %}
+  {%- do spec_lines.append('- name: "' ~ tool.name ~ '"') %}
+  {%- do spec_lines.append('  type: "' ~ tool.type ~ '"') %}
+  {%- if tool.title %}
+    {%- do spec_lines.append('  title: "' ~ tool.title ~ '"') %}
+  {%- endif %}
+  {%- if tool.description %}
+    {%- do spec_lines.append('  description: "' ~ tool.description ~ '"') %}
+  {%- endif %}
+  {%- if tool.identifier %}
+    {%- do spec_lines.append('  identifier: "' ~ tool.identifier ~ '"') %}
+  {%- endif %}
+  {%- if tool.config %}
+    {%- set tool_config = tool.config %}
+    {%- do spec_lines.append('  config:') %}
+    {%- do spec_lines.append('    type: "' ~ tool_config.type ~ '"') %}
+    {%- if tool_config.warehouse %}
+      {%- do spec_lines.append('    warehouse: "' ~ tool_config.warehouse ~ '"') %}
+    {%- endif %}
+    {%- if tool_config.input_schema %}
+      {%- set input_schema = tool_config.input_schema %}
+      {%- do spec_lines.append('    input_schema:') %}
+      {%- do spec_lines.append('      type: "' ~ input_schema.type ~ '"') %}
+      {%- if input_schema.properties %}
+        {%- do spec_lines.append('      properties:') %}
+        {%- for prop_name, prop in input_schema.properties.items() %}
+          {%- do spec_lines.append('        ' ~ prop_name ~ ':') %}
+          {%- if prop.description %}
+            {%- do spec_lines.append('          description: "' ~ prop.description ~ '"') %}
+          {%- endif %}
+          {%- if prop.type %}
+            {%- do spec_lines.append('          type: "' ~ prop.type ~ '"') %}
+          {%- endif %}
+        {%- endfor %}
+      {%- endif %}
+    {%- endif %}
+  {%- endif %}
+{%- endfor %}
+
+{%- set spec_yaml = spec_lines | join('\n') %}
+
+{%- set sql %}
+create or replace mcp server {{ server_name }}
+from specification $$
+{{ spec_yaml }}
+$$;
+{%- endset %}
+
+{{ log(sql, info=True) }}
+{% if not var('dry_run', False) %}
+  {{ run_query(sql) }}
+{% endif %}
+
+{%- endmacro -%}

--- a/macros/create_mcp_server.sql
+++ b/macros/create_mcp_server.sql
@@ -24,37 +24,37 @@
 {%- set spec_lines = [] %}
 {%- do spec_lines.append('tools:') %}
 {%- for tool in tools %}
-  {%- do spec_lines.append('- name: "' ~ tool.name ~ '"') %}
-  {%- do spec_lines.append('  type: "' ~ tool.type ~ '"') %}
+  {%- do spec_lines.append('  - name: "' ~ tool.name ~ '"') %}
+  {%- do spec_lines.append('    type: "' ~ tool.type ~ '"') %}
   {%- if tool.title %}
-    {%- do spec_lines.append('  title: "' ~ tool.title ~ '"') %}
+    {%- do spec_lines.append('    title: "' ~ tool.title ~ '"') %}
   {%- endif %}
   {%- if tool.description %}
-    {%- do spec_lines.append('  description: "' ~ tool.description ~ '"') %}
+    {%- do spec_lines.append('    description: "' ~ tool.description ~ '"') %}
   {%- endif %}
   {%- if tool.identifier %}
-    {%- do spec_lines.append('  identifier: "' ~ tool.identifier ~ '"') %}
+    {%- do spec_lines.append('    identifier: "' ~ tool.identifier ~ '"') %}
   {%- endif %}
   {%- if tool.config %}
     {%- set tool_config = tool.config %}
-    {%- do spec_lines.append('  config:') %}
-    {%- do spec_lines.append('    type: "' ~ tool_config.type ~ '"') %}
+    {%- do spec_lines.append('    config:') %}
+    {%- do spec_lines.append('      type: "' ~ tool_config.type ~ '"') %}
     {%- if tool_config.warehouse %}
-      {%- do spec_lines.append('    warehouse: "' ~ tool_config.warehouse ~ '"') %}
+      {%- do spec_lines.append('      warehouse: "' ~ tool_config.warehouse ~ '"') %}
     {%- endif %}
     {%- if tool_config.input_schema %}
       {%- set input_schema = tool_config.input_schema %}
-      {%- do spec_lines.append('    input_schema:') %}
-      {%- do spec_lines.append('      type: "' ~ input_schema.type ~ '"') %}
+      {%- do spec_lines.append('      input_schema:') %}
+      {%- do spec_lines.append('        type: "' ~ input_schema.type ~ '"') %}
       {%- if input_schema.properties %}
-        {%- do spec_lines.append('      properties:') %}
+        {%- do spec_lines.append('        properties:') %}
         {%- for prop_name, prop in input_schema.properties.items() %}
-          {%- do spec_lines.append('        ' ~ prop_name ~ ':') %}
+          {%- do spec_lines.append('          ' ~ prop_name ~ ':') %}
           {%- if prop.description %}
-            {%- do spec_lines.append('          description: "' ~ prop.description ~ '"') %}
+            {%- do spec_lines.append('            description: "' ~ prop.description ~ '"') %}
           {%- endif %}
           {%- if prop.type %}
-            {%- do spec_lines.append('          type: "' ~ prop.type ~ '"') %}
+            {%- do spec_lines.append('            type: "' ~ prop.type ~ '"') %}
           {%- endif %}
         {%- endfor %}
       {%- endif %}

--- a/snowflake/mcp_server/example_mcp_server.yml
+++ b/snowflake/mcp_server/example_mcp_server.yml
@@ -1,0 +1,33 @@
+server_name: analytics.dev_dcorley.my_mcp_server
+tools:
+  - name: product-search
+    type: CORTEX_SEARCH_SERVICE_QUERY
+    title: Product Search
+    identifier: database1.schema1.cortex_search_service1
+    description: Cortex search service for all products
+
+  - name: revenue-analyst
+    type: CORTEX_ANALYST_MESSAGE
+    title: Revenue Analyst
+    identifier: database1.schema1.revenue_semantic_view
+    description: Semantic view for all revenue tables
+
+  - name: sql-exec
+    type: SYSTEM_EXECUTE_SQL
+    title: SQL Execution Tool
+    description: A tool to execute SQL queries against the connected Snowflake database.
+
+  - name: multiply-by-ten
+    type: GENERIC
+    title: Multiply by Ten
+    identifier: example_database.agents.multiply_by_ten
+    description: Multiplies input value by ten and returns the result.
+    config:
+      type: function
+      warehouse: compute_service_warehouse
+      input_schema:
+        type: object
+        properties:
+          x:
+            description: A number to be multiplied by ten
+            type: number


### PR DESCRIPTION
This pull request introduces a new macro for managing Snowflake MCP (Model Context Protocol) servers and provides supporting documentation and configuration examples. The main focus is to streamline the creation and management of MCP servers via dbt, using a YAML-based configuration approach.

Key changes include:

**New Macro for MCP Server Management:**

* Added the `create_mcp_server` macro (`macros/create_mcp_server.sql`) to automate the creation or replacement of MCP servers in Snowflake. This macro takes a YAML file describing the server and its tools, qualifies server names based on the target profile, and constructs the required SQL specification.

**Documentation Updates:**

* Updated `README.md` to document the new `create_mcp_server` macro, including usage instructions, parameter descriptions, and a link to an example configuration.

**Example Configuration:**

* Added an example YAML configuration file (`snowflake/mcp_server/example_mcp_server.yml`) demonstrating how to define an MCP server and its tools, covering all supported tool types and configuration options.